### PR TITLE
Rework Docker container structure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+private
+.venv
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apk add \
     opus-dev \
     sqlite
 
-ADD requirements.txt /jukebox/requirements.txt
-RUN pip3 install -r /jukebox/requirements.txt
-
-CMD ["python3", "-u", "/jukebox/main.py"]
+RUN mkdir /jukebox
+ADD requirements.txt /jukebox
+ADD src /jukebox
+WORKDIR /jukebox
+RUN pip3 install -r requirements.txt
+CMD ["python", "-u", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
     jukebox:
-        image: jukebox:latest
+        image: aquova/jukebox:latest
         container_name: jukebox
         restart: unless-stopped
         volumes:
-            - ./src:/jukebox
             - ./private:/private


### PR DESCRIPTION
Reworks how the Docker containers are laid out. Instead of requiring the repo be checked out, then added as a volume to the image, the new docker image instead includes the source file inside the container. The only external file now required is a valid config.json.